### PR TITLE
Fix -i parameter

### DIFF
--- a/tools/ssh-copy-id.cmd
+++ b/tools/ssh-copy-id.cmd
@@ -10,7 +10,7 @@ SET identity_file=%userprofile%\.ssh\id_rsa.pub
 :loop
 IF NOT "%1"=="" (
     IF "%1"=="-i" (
-        SET i_file=%2
+        SET identity_file=%2
         SHIFT
     )
     SHIFT


### PR DESCRIPTION
While a friend of mine was trying to use this, we were having a bit of trouble trying to use a non-standard public key. In particular, they didnt have an `id_rsa.pub` file in their `.ssh` directory.

From what I can see, it seems that this script _only_ checks for `id_rsa.pub` even though it does have an input file available. But its unused, due to the differing variable names.

So this is just a quick correction for that, let me know if you need anything else!

